### PR TITLE
Recommend using npx to run the demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,8 @@ required.</p>
 
 
 ```bash
-# install
-$ npm install zero-demo -g
-
-# run it
-$ zero-demo
+# run demo
+$ npx zero-demo
 ```
 
 


### PR DESCRIPTION
Globally installing `zero-demo` and running the binary seems unnecessary
`npx` is included as part of `npm` (and therefore part of `node`)