### PR TITLE
Changes the way the render loop is called to setImmediate(loop)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zero-demo",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function loop () {
     renderer.clear(Vector4.create(1, 1, 1, 0))
     renderer.render(camera, scene)
 
-    setTimeout(() => loop())
+    setImmediate(loop)
 }
 
 loop()


### PR DESCRIPTION
Addresses the issue #9 

In `index.ts:79`, instead of

`    setTimeout(() => loop())`

I've

`    setImmediate(() => loop())`

or

`    setImmediate(loop)`

with a substantial performance increase (on 120x28 the demo went from avg. ~65fps to ~250fps, on 237x70 it went from avg. ~30 fps to ~64 fps).

Other tests I did were with a `while(1)` inside the loop function, converting the loop function to an async function and having it's callback call it again, and having the next iteration of the function set up to run with `process.nextTick`. All of those are also faster than `setTimeout`, but they seem to hang the process on the loop and disallow other event handlers and callbacks to run.

* [This StackOverflow thread on NodeJS' setTimeout(fn,0) vs setImmediate(fn)]( https://stackoverflow.com/questions/24117267/nodejs-settimeoutfn-0-vs-setimmediatefn/24119936#24119936 )

* [Node's Timers, setImmediate]( https://nodejs.org/api/timers.html#timers_setimmediate_callback_args )